### PR TITLE
Organized Placeholders

### DIFF
--- a/js/build_helpers/templater.js
+++ b/js/build_helpers/templater.js
@@ -16,7 +16,8 @@ fs.readdirSync(`${markdownSource}/help`).forEach((source) => {
       `${markdownSource}/help/${source}`,
       "utf-8"
     );
-    const parsed = marked.parse(markdownContent);
+    var parsed = marked.parse(markdownContent);
+	parsed = parsed.replace(/{{_/g,  "{{HELP_" + title.toUpperCase() + "_");
     htmlString += `
     <details id="${title}">
       <summary>{{HELP_${title.toUpperCase()}}}</summary>
@@ -42,10 +43,14 @@ const createIndexHtml = () => {
   console.log("Replacing WELCOME");
   try {
     let welcome = fs.readFileSync(`${markdownSource}/welcome.md`, "utf-8");
+	
+	var parsed = marked.parse(welcome);
+	parsed = parsed.replace(/{{_/g,  "{{WELCOME_");
+	
     let welcomeHtml = `
     <details id="welcome">
       <summary>{{WELCOME}}</summary>
-      <div>${marked.parse(welcome)}</div>
+      <div>${parsed}</div>
     </details>`;
     template = template.replace(/\[\[WELCOME\]\]/g, welcomeHtml);
     console.log("WELCOME replaced");
@@ -63,7 +68,7 @@ const createIndexHtml = () => {
     let orgs = fs.readFileSync(`${markdownSource}/organizations.md`, "utf-8");
     template = template.replace(
       /\[\[ORGANIZATIONS\]\]/g,
-      marked.parse(orgs).replace("<p>", '<p class="centered">')
+      marked.parse(orgs).replace("<p>", '<p class="centered">').replace(/{{_/g,  "{{ORGANIZATIONS_")
     );
     console.log("ORGANIZATIONS replaced");
   } catch (e) {
@@ -82,7 +87,7 @@ const createIndexHtml = () => {
   console.log("Replacing IMPRESSUM...");
   try {
     let impressum = fs.readFileSync(`${markdownSource}/impressum.md`, "utf-8");
-    template = template.replace(/\[\[IMPRESSUM\]\]/g, marked.parse(impressum));
+    template = template.replace(/\[\[IMPRESSUM\]\]/g, marked.parse(impressum).replace(/{{_/g,  "{{IMPRESSUM_"));
     console.log("IMPRESSUM replaced");
   } catch (e) {
     console.log("Error replacing IMPRESSUM");

--- a/js/build_helpers/translator.js
+++ b/js/build_helpers/translator.js
@@ -1,46 +1,60 @@
 async function getTranslations() {
   const { GoogleSpreadsheet } = require("google-spreadsheet");
 
-  try {
-    const doc = new GoogleSpreadsheet(process.env.GOOGLE_TRANSLATIONS_KEY);
-    doc.useApiKey(process.env.GOOGLE_API_KEY);
-
-    console.log("\nConnecting to Google Docs");
-    await doc.loadInfo();
-
-    const sheet = doc.sheetsByIndex[0];
-    const rows = await sheet.getRows();
-
-    console.log("Building EN dictionary");
-    const en = new Map([]);
-    rows.forEach((row) => {
-      en.set(`{{${row.LABEL}}}`, row.EN);
-    });
-
-    console.log("Building UK dictionary");
-    const uk = new Map([]);
-    rows.forEach((row) => {
-      uk.set(`{{${row.LABEL}}}`, row.UK);
-    });
-
-    console.log("Building HU dictionary");
-    const hu = new Map([]);
-    rows.forEach((row) => {
-      hu.set(`{{${row.LABEL}}}`, row.HU);
-    });
-
-    return { en, uk, hu };
-  } catch {
-    console.log("Could't connect to Google Docs. Displaying raw labels");
-    const mockMap = new Map([
+	const defaultMap = new Map([
       ["{{CSS_SRC}}", "../css"],
       ["{{IMG_SRC}}", "../img"]
     ]);
-    return {
-      en: mockMap,
-      hu: mockMap,
-      uk: mockMap
-    }
+	var defaultReturn = {
+	  'en': defaultMap,
+      'hu': defaultMap,
+      'uk': defaultMap
+	}
+
+	var doc = new Object();
+	try {
+		process.stdout.write("\nConnecting to Google Docs");
+		doc = new GoogleSpreadsheet(process.env.GOOGLE_TRANSLATIONS_KEY);
+		doc.useApiKey(process.env.GOOGLE_API_KEY);	
+		await doc.loadInfo();
+	} catch(e) {	  		
+		console.log("Could't connect to Google Docs. Displaying raw labels");
+		console.log(e);
+		return defaultReturn;
+	}
+	process.stdout.write(" [done]\n");
+
+	try {	
+		const en = new Map([]);
+		const uk = new Map([]);
+		const hu = new Map([]);
+		
+		console.log("Building dictionaries");
+		
+		for (let i = 0; i < doc.sheetCount; i++) {
+
+			const sheet = doc.sheetsByIndex[i];
+			process.stdout.write("    Reading sheet: " + sheet.title + " ");
+			if(i == 0) process.stdout.write("(default) ");
+		
+			const rows = await sheet.getRows();
+					
+			rows.forEach((row) => {
+			  process.stdout.write(".");
+			  
+			  row.LABEL = row.LABEL.replace(/^_/, sheet.title + "_");
+			  			 
+			  en.set(`{{${row.LABEL}}}`, row.EN);			
+			  uk.set(`{{${row.LABEL}}}`, row.UK);
+			  hu.set(`{{${row.LABEL}}}`, row.HU);
+			});
+			process.stdout.write(" [done]\n");
+		}
+		return { en, uk, hu };
+  } catch(e) {
+	console.log(e);
+    console.log("Could't connect create dictionaries. Displaying raw labels");
+    return defaultReturn;
   }
 }
 


### PR DESCRIPTION
To make the placeholders unique without thinking a lot now you can begin a placeholder with '_' and templater will complete if with the filename. For example if you write {{_PHONE}} in the file help/04_housing.md then the templater interprets it as "{{HELP_HOUSING_PHONE}}" . Cleaner and safer approach.

From now you can use multiple sheets in the google spreadsheet so as to make the translation more readable. The translator.js will read all the sheets. And there is more: you can use the same leading "_" in the LABEL column to make your work easier. The translator than adds the name of the sheet to the beginning of tha label. So when you write _PHONE to the value cell in the sheet named "HELP_HOUSING" the translator will have the HELP_HOUSING_PHONE item.

